### PR TITLE
fix: correct baseurl references in includes

### DIFF
--- a/_includes/blog-old.html
+++ b/_includes/blog-old.html
@@ -22,7 +22,7 @@
 {%- assign nextpage = thispage | plus: 1 -%}
 {%- assign nextpagename = pagename | append: nextpage -%}
 
-<section id="main-banner-page" class="position-relative page-header blog2-header section-nav-smooth" style="background-image: url('{{- sitec.baseurl -}}/assets/images/shutterstock_394634593-cropped.jpg')" data-parallaxie='{ "speed": -0.8 "size": "auto">, "offset": 100 }'>
+<section id="main-banner-page" class="position-relative page-header blog2-header section-nav-smooth" style="background-image: url('{{- site.baseurl -}}/assets/images/shutterstock_394634593-cropped.jpg')" data-parallaxie='{ "speed": -0.8 "size": "auto">, "offset": 100 }'>
   <div class="overlay overlay-dark opacity-4 z-index-1"></div>
   <div class="container">
       <div class="row">

--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -27,7 +27,7 @@
 <!-- Permanently scale thumbnails - force crop -->
 <!-- Adjust bars in blog & contact us to show full range of RX2 colors -->
 
-<section id="main-banner-page" class="position-relative page-header blog2-header section-nav-smooth" style="background-image: url('{{- sitec.baseurl -}}/assets/images/shutterstock_394634593-cropped.jpg')">
+<section id="main-banner-page" class="position-relative page-header blog2-header section-nav-smooth" style="background-image: url('{{- site.baseurl -}}/assets/images/shutterstock_394634593-cropped.jpg')">
     <div class="overlay overlay-dark opacity-4 z-index-1"></div>
     <div class="container">
         <div class="row">

--- a/_includes/contactus.html
+++ b/_includes/contactus.html
@@ -1,6 +1,6 @@
 {%- assign show_map = "true" -%}
 
-<section id="main-banner-page" class="position-relative page-header blog2-header section-nav-smooth" style="background-image: url('{{- sitec.baseurl -}}/assets/images/shutterstock_394634593-cropped.jpg')">
+<section id="main-banner-page" class="position-relative page-header blog2-header section-nav-smooth" style="background-image: url('{{- site.baseurl -}}/assets/images/shutterstock_394634593-cropped.jpg')">
     <div class="overlay overlay-dark opacity-4 z-index-1"></div>
     <div class="container">
         <div class="row">


### PR DESCRIPTION
## Summary
- use `site.baseurl` instead of `sitec.baseurl` in blog and contact include templates

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68c59da3dad483279f2ab8d5c4f844cc