### PR TITLE
Format landing form includes

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -33,12 +33,7 @@
               {% endif %}
             </div>
             <div class="lp-hero-form">
-              {% include landing/form.html
-                id="lp-optin-top"
-                endpoint=page.api_endpoint
-                heading=page.offer_download_title
-                asset=page.offer_asset_highlight
-                submit_label=top_submit_label %}
+              {% include landing/form.html id="lp-optin-top" endpoint=page.api_endpoint heading=page.offer_download_title asset=page.offer_asset_highlight submit_label=top_submit_label %}
             </div>
           </div>
         </div>
@@ -92,12 +87,7 @@
 
       <footer class="lp-footer">
         <div class="container">
-          {% include landing/form.html
-            id="lp-optin-bottom"
-            endpoint=page.api_endpoint
-            heading=footer_heading
-            asset=footer_asset
-            submit_label=bottom_submit_label %}
+          {% include landing/form.html id="lp-optin-bottom" endpoint=page.api_endpoint heading=footer_heading asset=footer_asset submit_label=bottom_submit_label %}
           <p class="lp-consent">{{ page.consent_copy | default: 'We send practical hiring insights once a week. Unsubscribe anytime.' }}</p>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- collapse landing page form includes into single-line Liquid tags to match formatting request

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable missing and Bundler cannot install dependencies due to 403 when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68da8cf7a0c0832780be598779fa2abe